### PR TITLE
fix: Allow localhost to be http

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -154,7 +154,7 @@ function checkOrigin(str) {
         throw new Error("origin was malformatted");
     }
 
-    if (originUrl.protocol !== "https:") {
+    if (originUrl.protocol !== "https:" && originUrl.hostname !== "localhost") {
         throw new Error("origin should be https");
     }
 


### PR DESCRIPTION
This is in line with Chrome/Firefox, which allow localhost for secure contexts like `navigator.credentials`.

Without this it's gooing to be much harder to test.

Test itself is stolen from the line below.