### PR TITLE
fix rawAuthnrData parse

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -256,7 +256,7 @@ function parseAuthnrAssertionResponse(msg) {
     let ret = new Map([
         ["sig", sigAb],
         ["userHandle", userHandle],
-        ["rawAuthnrData", msg.response.authenticatorData],
+        ["rawAuthnrData", coerceToArrayBuffer(msg.response.authenticatorData, "authenticatorData")],
         ...parseAuthenticatorData(msg.response.authenticatorData)
     ]);
 


### PR DESCRIPTION
now in hackathon mode, can provide details later. But it looks like a type and breaking `f2l.assertionResult`